### PR TITLE
rtl8192cu: Fix build for kernel 5.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 *.ko
 *.so
 *.so.dbg
+*.mod
 *.mod.c
 *.i
 *.lst

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -1782,19 +1782,23 @@ static int isFileReadable(char *path)
 {
 	struct file *fp;
 	int ret = 0;
+#ifdef set_fs
 	mm_segment_t oldfs;
+#endif
 	char buf;
 
 	fp=filp_open(path, O_RDONLY, 0);
 	if(IS_ERR(fp)) {
 		ret = PTR_ERR(fp);
 	} else {
+#ifdef set_fs
 		oldfs = get_fs(); set_fs(KERNEL_DS);
-
+#endif
 		if(1!=readFile(fp, &buf, 1))
 			ret = PTR_ERR(fp);
-
+#ifdef set_fs
 		set_fs(oldfs);
+#endif
 		filp_close(fp,NULL);
 	}
 	return ret;
@@ -1810,16 +1814,21 @@ static int isFileReadable(char *path)
 static int retriveFromFile(char *path, u8* buf, u32 sz)
 {
 	int ret =-1;
+#ifdef set_fs
 	mm_segment_t oldfs;
+#endif
 	struct file *fp;
 
 	if(path && buf) {
 		if( 0 == (ret=openFile(&fp,path, O_RDONLY, 0)) ){
 			DBG_871X("%s openFile path:%s fp=%p\n",__FUNCTION__, path ,fp);
-
+#ifdef set_fs
 			oldfs = get_fs(); set_fs(KERNEL_DS);
+#endif
 			ret=readFile(fp, buf, sz);
+#ifdef set_fs
 			set_fs(oldfs);
+#endif
 			closeFile(fp);
 
 			DBG_871X("%s readFile, ret:%d\n",__FUNCTION__, ret);
@@ -1844,16 +1853,22 @@ static int retriveFromFile(char *path, u8* buf, u32 sz)
 static int storeToFile(char *path, u8* buf, u32 sz)
 {
 	int ret =0;
+#ifdef set_fs
 	mm_segment_t oldfs;
+#endif
 	struct file *fp;
 
 	if(path && buf) {
 		if( 0 == (ret=openFile(&fp, path, O_CREAT|O_WRONLY, 0666)) ) {
 			DBG_871X("%s openFile path:%s fp=%p\n",__FUNCTION__, path ,fp);
 
+#ifdef set_fs
 			oldfs = get_fs(); set_fs(KERNEL_DS);
+#endif
 			ret=writeFile(fp, buf, sz);
+#ifdef set_fs
 			set_fs(oldfs);
+#endif
 			closeFile(fp);
 
 			DBG_871X("%s writeFile, ret:%d\n",__FUNCTION__, ret);


### PR DESCRIPTION
Since linux kernel 5.10 set_fs() was removed:
https://lwn.net/Articles/832121/

This patch fixes compilation for newer kernels
and keeps compatibility with older.
Inspired by:
https://github.com/Mange/rtl8192eu-linux-driver/commit/8ba6813bfd8c0d3a796dc0a441458d017ec9df15

Signed-off-by: Viktor Yakovchuk <viktor@yakovchuk.net>